### PR TITLE
adding fortitude linter and github action

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,30 @@
+name: Static Analysis
+
+on:
+  workflow_dispatch:
+  release:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Apply Fortran linter, fortitude
+        run: |
+          cd ${{ github.workspace }}
+          fortitude check --file-extensions=fypp

--- a/fortitude.toml
+++ b/fortitude.toml
@@ -1,0 +1,4 @@
+[check]
+ignore = ["E001","F001","M001","M011","T001","T031","T042","T041","S001"]
+line-length = 132
+file-extensions = ["fypp"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+fortitude-lint

--- a/src/lib/cinter_m.fypp
+++ b/src/lib/cinter_m.fypp
@@ -21,7 +21,7 @@
 module cinter_m
 
    ! Uses
-   
+
    use kinds_m
 
    use ISO_FORTRAN_ENV

--- a/src/lib/const_m.fypp
+++ b/src/lib/const_m.fypp
@@ -42,7 +42,7 @@ module const_m
    real(RD), parameter :: G_GRAVITY = 6.67430e-8_RD                ! Gravitational constant (CODATA 2018)
    real(RD), parameter :: C_LIGHT = 2.99792458E10_RD               ! Speed of light in vacuuo (CODATA 2018)
    real(RD), parameter :: SIGMA_STEFAN = 5.670374419E-5_RD         ! Stefan's constant (CODATA 2018)
-   real(RD), parameter :: A_RADIATION = 4._RD*SIGMA_STEFAN/C_LIGHT ! Radiation constant
+   real(RD), parameter :: A_RADIATION = 4._RD*SIGMA_STEFAN/C_LIGHT  ! Radiation constant
    real(RD), parameter :: H_PLANCK =  6.62606896E-27_RD            ! Planck's constant
    real(RD), parameter :: K_BOLTZMANN = 1.3806504E-16_RD           ! Boltzmann's constant
    real(RD), parameter :: U_ATOMIC = 1.660538782E-24_RD            ! Atomic mass unit
@@ -60,7 +60,7 @@ module const_m
    real(RD), parameter :: R_SUN = 6.957E10_RD       ! Nominal solar radius (IAU 2015 resolution B3)
    real(RD), parameter :: L_SUN = 3.828E33_RD       ! Nominal solar luminosity (IAU 2015 resolution B3)
    real(RD), parameter :: AU = 1.495978707E13_RD    ! Astronomical unit (IAU 2012 resolution B2)
-   real(RD), parameter :: PARSEC = AU*648000._RD/PI ! Parsec (IAU 2015 resolution B2)
+   real(RD), parameter :: PARSEC = AU*648000._RD/PI  ! Parsec (IAU 2015 resolution B2)
 
    ! Filename lengths etc
 

--- a/src/lib/forum_m.fypp
+++ b/src/lib/forum_m.fypp
@@ -49,7 +49,7 @@ module forum_m
       public :: f_c_string
 
       ! cinter_m
- 
+
       public :: PI
       public :: TWOPI
       public :: HALFPI
@@ -72,7 +72,7 @@ module forum_m
       public :: M_SUN
       public :: R_SUN
       public :: L_SUN
-      public :: FILENAME_LEN 
+      public :: FILENAME_LEN
 
       ! hdf5io_m
 
@@ -101,7 +101,7 @@ module forum_m
       public :: locate
 
       ! string_m
- 
+
       public :: get
       public :: put
       public :: extract
@@ -125,5 +125,5 @@ module forum_m
       public
 
    #:endif
-      
+
 end module forum_m

--- a/src/lib/hdf5io_m.fypp
+++ b/src/lib/hdf5io_m.fypp
@@ -97,21 +97,21 @@ module hdf5io_m
    end type hdf5io_t
 
    ! Module variables
-  
+
    integer, save :: ref_count = 0
 
    #:for suffix in NUM_SUFFIXES
       integer(HID_T), save :: mem_type_id_${suffix}$
       integer(HID_T), save :: file_type_id_${suffix}$
    #:endfor
-      
+
    ! Interfaces
 
    interface hdf5io_t
       module procedure hdf5io_t_file_
       module procedure hdf5io_t_group_
    end interface hdf5io_t
-   
+
    ! Access specifiers
 
    private
@@ -122,7 +122,7 @@ module hdf5io_m
    public :: TYPE_LEN
    public :: hdf5io_t
    public :: is_hdf5
-   
+
    ! Procedures
 
 contains
@@ -171,7 +171,7 @@ contains
       hi%group_id = group_id
 
       hi%access_type = access_type
-      
+
       allocate(hi%ref_count)
       hi%ref_count = 1
 
@@ -414,7 +414,7 @@ contains
          return
 
       contains
-      
+
          function op_len_(group_id, c_name, c_info, c_data) result(ret_value) bind(C)
 
             integer(HID_T), value :: group_id
@@ -486,7 +486,7 @@ contains
          end function op_name_
 
       end function ${obj_type}$_names
-         
+
    #:endfor
 
    !****
@@ -626,7 +626,7 @@ contains
          #:endfor
 
          #:for type, suffix in zip(CHAR_TYPES, CHAR_SUFFIXES)
-            
+
             subroutine read_${obj_type}$_${suffix}$_${rank}$_(self, item_name, data)
 
                class(hdf5io_t), intent(inout) :: self
@@ -653,7 +653,7 @@ contains
                   @:ASSERT(ALL(item_shape == SHAPE(data)), 'shape mismatch')
 
                #:endif
-         
+
                ! Read the character item
 
                @:HDF5_CALL(h5tcopy_f, H5T_NATIVE_CHARACTER, mem_type_id)
@@ -675,8 +675,8 @@ contains
 
          #:endfor
 
-         #:for type, suffix in zip(LOGICAL_TYPES, LOGICAL_SUFFIXES)   
-            
+         #:for type, suffix in zip(LOGICAL_TYPES, LOGICAL_SUFFIXES)
+
             subroutine read_${obj_type}$_${suffix}$_${rank}$_(self, item_name, data)
 
                class(hdf5io_t), intent(inout) :: self
@@ -701,7 +701,7 @@ contains
             end subroutine read_${obj_type}$_${suffix}$_${rank}$_
 
          #:endfor
-            
+
       #:endfor
    #:endfor
 
@@ -710,7 +710,7 @@ contains
    #:for obj_type in ('attr', 'dset')
       #:for rank in range(RANK_MAX+1)
          #:for type, suffix in zip(ALL_TYPES, ALL_SUFFIXES)
-         
+
             subroutine alloc_read_${obj_type}$_${suffix}$_${rank}$_(self, item_name, data)
 
                class(hdf5io_t), intent(inout)     :: self
@@ -722,7 +722,7 @@ contains
                #:endif
 
                ! Allocate the item
-                  
+
                #:if rank > 0
 
                   item_shape = self%${obj_type}$_shape(item_name)
@@ -762,7 +762,7 @@ contains
             #:else
             subroutine write_${obj_type}$_${suffix}$_${rank}$_(self, item_name, data)
             #:endif
-            
+
                class(hdf5io_t), intent(inout) :: self
                character(*), intent(in)       :: item_name
                ${type}$, target, intent(in)   :: data${ARRAY_SPEC(rank)}$

--- a/src/lib/kinds_m.fypp
+++ b/src/lib/kinds_m.fypp
@@ -23,7 +23,7 @@ module kinds_m
    use ISO_FORTRAN_ENV
 
    ! No implicit typing
-   
+
    implicit none
 
    ! Parameter definitions

--- a/src/lib/order_m.fypp
+++ b/src/lib/order_m.fypp
@@ -513,7 +513,7 @@ contains
          ${type}$, intent(in)          :: x_loc
          integer, intent(out)          :: i_loc
          logical, intent(in), optional :: right
-         
+
          logical :: right_
 
          if (PRESENT(right)) then
@@ -526,7 +526,7 @@ contains
          !
          !   x_0 + (i_loc-1)*dx <= x_loc < x_0 + i_loc*dx     if left
          !   x_0 + (i_loc-2)*dx < x_loc <= x_0 + (i_loc-1)*dx if .NOT. left
-         
+
          if (right_) then
 
             i_loc = CEILING((x_loc - x_0)/dx) + 1
@@ -537,7 +537,7 @@ contains
          else
 
             i_loc = FLOOR((x_loc - x_0)/dx) + 1
-         
+
             if (x_0 + (i_loc-1)*dx > x_loc) i_loc = i_loc - 1
             if (x_0 + i_loc*dx <= x_loc) i_loc = i_loc + 1
 

--- a/src/lib/system_m.fypp
+++ b/src/lib/system_m.fypp
@@ -39,7 +39,7 @@ module system_m
          module procedure get_arg_name_${suffix}$_
       end interface get_arg
 
-      interface get_env 
+      interface get_env
          module procedure get_env_${suffix}$_
       end interface get_env
 
@@ -113,7 +113,7 @@ contains
       end subroutine get_arg_${suffix}$_
 
       !****
-      
+
       subroutine get_arg_name_${suffix}$_(name, value, status, first, last)
 
          character(*), intent(in)       :: name
@@ -181,7 +181,7 @@ contains
                      return
 
                   end if
-                  
+
                endif
 
                deallocate(buffer)
@@ -312,7 +312,7 @@ contains
                      return
 
                   end if
-                  
+
                endif
 
                deallocate(buffer)
@@ -332,7 +332,7 @@ contains
       end subroutine get_arg_name_${suffix}$_
 
    #:endfor
-      
+
    !****
 
    #:for type, suffix in zip(MATH_TYPES,MATH_SUFFIXES)
@@ -420,5 +420,5 @@ contains
       end subroutine get_env_${suffix}$_
 
    #:endfor
-      
+
 end module system_m


### PR DESCRIPTION
The [fortitude linter](https://github.com/PlasmaFAIR/fortitude) can catch some important Fortran errors, and help clean up code and meet modern Fortran standards. It is installable via pip: `pip install fortitude-lint` and can be run in the terminal in this project as: 

```
fortitude check --file-extensions=fypp
```

There is a `fortitude.toml` file that sets some extra configurations and errors to ignore.

Check it out if you'd like! Right now I disabled some of the checks in the .toml file because there are a bunch to potentially fix. But it is applying some formatting fixes. Fortitude can fix some errors automatically by adding the `--fix` flag when calling it in the command line

I also added a github action that will always perform static analysis on the code

Feel free to merge if you think this could be useful, or ignore if not.